### PR TITLE
Support audio drag-and-drop and refine default titles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ LESSON_SCRIBE_DEFAULT_TITLE=Leçon
 # dans le formulaire d'ajout de leçon.
 LESSON_SCRIBE_DEFAULT_TIME=09:00-10:00
 
+# Dossier initial de la boîte de dialogue audio (facultatif)
+# Spécifiez un dossier existant pour que « Choisir un fichier… » s’ouvre directement dedans.
+LESSON_SCRIBE_AUDIO_DIALOG_PATH=/chemin/vers/mes/audios
+
 # Configuration de Vibe (facultatif)
 # VIBE_CLI peut pointer vers le binaire `vibe` si celui-ci n'est pas déjà dans votre PATH.
 VIBE_CLI=/chemin/vers/vibe

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ pip install -e .
 > Astuce : `invoke install --dev` installe le projet en mode editable avec les
 > dépendances de développement.
 
+> Remarque : la prise en charge du glisser-déposer global de l’audio s’appuie sur
+> [`tkinterdnd2`](https://pypi.org/project/tkinterdnd2/), installé automatiquement
+> via `requirements.txt`.
+
 ## Lancement de l’application
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,10 +58,6 @@ pip install -e .
 > Astuce : `invoke install --dev` installe le projet en mode editable avec les
 > dépendances de développement.
 
-> Remarque : la prise en charge du glisser-déposer global de l’audio s’appuie sur
-> [`tkinterdnd2`](https://pypi.org/project/tkinterdnd2/), installé automatiquement
-> via `requirements.txt`.
-
 ## Lancement de l’application
 
 ```bash
@@ -85,6 +81,9 @@ ajustez les valeurs selon votre environnement :
 * `LESSON_SCRIBE_DEFAULT_TIME` (alias : `LESSON_DEFAULT_TIME`) : horaire à
   pré-remplir lors de la création d’une leçon. Utilisez `HH:MM-HH:MM` pour une
   plage complète ou uniquement `HH:MM` pour renseigner l’heure de début.
+* `LESSON_SCRIBE_AUDIO_DIALOG_PATH` (alias : `LESSON_AUDIO_DIALOG_PATH`) : dossier
+  ouvert par défaut lorsque vous cliquez sur « Choisir un fichier… » pour
+  sélectionner un audio.
 * `VIBE_CLI`, `VIBE_MODEL_PATH`, `VIBE_LANGUAGE`, `VIBE_THREADS`,
   `VIBE_TEMPERATURE` : paramètres optionnels pour piloter Vibe.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyperclip>=1.8
 python-dotenv>=1.0
 numpy>=1.23
 sounddevice>=0.4
+tkinterdnd2>=0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pyperclip>=1.8
 python-dotenv>=1.0
 numpy>=1.23
 sounddevice>=0.4
-tkinterdnd2>=0.4.2

--- a/src/lesson_scribe/app.py
+++ b/src/lesson_scribe/app.py
@@ -315,22 +315,16 @@ class LessonDialog(tk.Toplevel):
             foreground="#555555",
         )
         record_status_label.grid(row=2, column=0, columnspan=3, sticky="we", padx=4, pady=(0, 4))
-        self._initialize_audio_drag_and_drop(
-            highlight_widget=self.audio_display_label,
-            widgets=[
-                audio_box,
-                self.audio_display_label,
-                choose_button,
-                clear_button,
-                record_button,
-                record_status_label,
-            ],
-        )
-
         buttons = ttk.Frame(container)
         buttons.grid(row=row + 1, column=0, columnspan=2, sticky="e", pady=(6, 0))
         ttk.Button(buttons, text="Annuler", command=self._on_cancel).grid(row=0, column=0, padx=6)
         ttk.Button(buttons, text="Enregistrer", command=self.on_save).grid(row=0, column=1, padx=6)
+
+        drop_targets = self._collect_audio_drop_widgets(self)
+        self._initialize_audio_drag_and_drop(
+            highlight_widget=self.audio_display_label,
+            widgets=drop_targets,
+        )
 
         self.protocol("WM_DELETE_WINDOW", self._on_cancel)
         self.wait_visibility()
@@ -394,6 +388,22 @@ class LessonDialog(tk.Toplevel):
         self._audio_drop_highlight_widget = highlight_widget
         for widget in widgets:
             self._register_audio_drop_target(widget)
+
+    def _collect_audio_drop_widgets(self, root: tk.Widget) -> list[tk.Widget]:
+        widgets: list[tk.Widget] = []
+        seen: set[str] = set()
+
+        def visit(widget: tk.Widget) -> None:
+            widget_id = str(widget)
+            if widget_id in seen:
+                return
+            seen.add(widget_id)
+            widgets.append(widget)
+            for child in widget.winfo_children():
+                visit(child)
+
+        visit(root)
+        return widgets
 
     def _register_audio_drop_target(self, widget: tk.Widget) -> None:
         if widget in self._audio_drop_targets:

--- a/src/lesson_scribe/app.py
+++ b/src/lesson_scribe/app.py
@@ -37,8 +37,12 @@ else:
     TkinterDnD = None
 
 if TkinterDnD is not None:
-    BaseTk = cast(type[tk.Tk], TkinterDnD.Tk)
-    BaseToplevel = cast(type[tk.Toplevel], TkinterDnD.Toplevel)
+    BaseTk = cast(type[tk.Tk], getattr(TkinterDnD, "Tk", tk.Tk))
+    _DnDToplevel = getattr(TkinterDnD, "Toplevel", None)
+    if _DnDToplevel is None:
+        BaseToplevel = tk.Toplevel
+    else:
+        BaseToplevel = cast(type[tk.Toplevel], _DnDToplevel)
 else:  # pragma: no cover - mode sans drag-and-drop natif
     BaseTk = tk.Tk
     BaseToplevel = tk.Toplevel

--- a/src/lesson_scribe/app.py
+++ b/src/lesson_scribe/app.py
@@ -36,6 +36,7 @@ except Exception:  # pragma: no cover - dépendances optionnelles
 APP_NAME = "Lesson Scribe"
 WORKSPACE_VERSION = 1
 TRANSCRIPT_HEADER = "\n\n--- Transcription Vibe ---\n"
+AUDIO_FILE_EXTENSIONS = {".wav", ".mp3", ".m4a", ".aac", ".flac", ".ogg"}
 HELP_TEXT = (
     "Bienvenue dans Lesson Scribe !\n\n"
     "1. Ouvre ou crée un workspace.\n"
@@ -214,8 +215,7 @@ class LessonDialog(tk.Toplevel):
         self.var_end = tk.StringVar(value=initial.end or "")
         self.var_minutes = tk.StringVar(value=format_minutes(initial.minutes))
 
-        audio_display = self.initial_audio_path or "Aucun fichier audio"
-        self.var_audio_display = tk.StringVar(value=audio_display)
+        self.var_audio_display = tk.StringVar()
         self.var_record_button = tk.StringVar(value="Enregistrer…")
         self.var_record_status = tk.StringVar(value="Aucun enregistrement en cours.")
 
@@ -232,6 +232,8 @@ class LessonDialog(tk.Toplevel):
         self._record_timer_job: str | None = None
         self._recording_status_message: str | None = None
         self._temp_recordings: set[str] = set()
+        self._audio_drop_enabled = False
+        self._audio_drop_target: tk.Widget | None = None
 
         container = ttk.Frame(self, padding=12)
         container.grid(row=0, column=0, sticky="nsew")
@@ -284,9 +286,20 @@ class LessonDialog(tk.Toplevel):
         audio_box.columnconfigure(1, weight=0)
         audio_box.columnconfigure(2, weight=0)
 
-        ttk.Label(audio_box, textvariable=self.var_audio_display, wraplength=380).grid(
-            row=0, column=0, columnspan=3, sticky="we", padx=4, pady=(4, 2)
+        self.audio_display_label = tk.Label(
+            audio_box,
+            textvariable=self.var_audio_display,
+            wraplength=380,
+            anchor="w",
+            justify="left",
+            relief="groove",
+            padx=6,
+            pady=4,
         )
+        self.audio_display_label.grid(row=0, column=0, columnspan=3, sticky="we", padx=4, pady=(4, 2))
+        self._audio_drop_default_bg = self.audio_display_label.cget("background")
+        self._setup_audio_drag_and_drop(self.audio_display_label)
+        self._refresh_audio_display_text(self.initial_audio_path or None)
         ttk.Button(audio_box, text="Choisir un fichier…", command=self.select_audio_file).grid(
             row=1, column=0, sticky="w", padx=4, pady=(0, 4)
         )
@@ -328,12 +341,7 @@ class LessonDialog(tk.Toplevel):
         )
         if not path:
             return
-        if self._audio_source_is_temp and self.audio_source_path:
-            self._discard_temp_recording(self.audio_source_path)
-        self.audio_source_path = path
-        self.audio_cleared = False
-        self._audio_source_is_temp = False
-        self.var_audio_display.set(path)
+        self._apply_selected_audio_file(path)
 
     def clear_audio_file(self) -> None:
         self.stop_audio_recording(keep_result=False, show_message=False)
@@ -343,7 +351,82 @@ class LessonDialog(tk.Toplevel):
         self.audio_cleared = True
         self.initial_audio_path = ""
         self._audio_source_is_temp = False
-        self.var_audio_display.set("Aucun fichier audio")
+        self._refresh_audio_display_text(None)
+
+    def _apply_selected_audio_file(self, path: str) -> None:
+        if self._audio_source_is_temp and self.audio_source_path:
+            self._discard_temp_recording(self.audio_source_path)
+        self.audio_source_path = path
+        self.audio_cleared = False
+        self._audio_source_is_temp = False
+        self._refresh_audio_display_text(path)
+
+    def _refresh_audio_display_text(self, path: str | None) -> None:
+        if path:
+            self.var_audio_display.set(path)
+        else:
+            if self._audio_drop_enabled:
+                self.var_audio_display.set(
+                    "Aucun fichier audio — glisser-déposer un fichier ici ou cliquer sur ‘Choisir un fichier…’"
+                )
+            else:
+                self.var_audio_display.set("Aucun fichier audio")
+
+    def _setup_audio_drag_and_drop(self, widget: tk.Widget) -> None:
+        try:
+            widget.tk.call("package", "require", "tkdnd")
+        except tk.TclError:
+            return
+        self._audio_drop_enabled = True
+        self._audio_drop_target = widget
+        widget.tk.call("tkdnd::drop_target", "register", widget._w, "DND_Files")
+        drop_cmd = widget.register(self._on_audio_drop)
+        widget.tk.call("bind", widget._w, "<<Drop>>", f"{{{drop_cmd} %D}}")
+        enter_cmd = widget.register(self._on_audio_drag_enter)
+        leave_cmd = widget.register(self._on_audio_drag_leave)
+        widget.tk.call("bind", widget._w, "<<DragEnter>>", f"{{{enter_cmd} %D}}")
+        widget.tk.call("bind", widget._w, "<<DragLeave>>", f"{{{leave_cmd} %D}}")
+
+    def _on_audio_drag_enter(self, _data: str) -> str:
+        self._set_audio_drop_highlight(True)
+        return ""
+
+    def _on_audio_drag_leave(self, _data: str) -> str:
+        self._set_audio_drop_highlight(False)
+        return ""
+
+    def _on_audio_drop(self, data: str) -> str:
+        self._set_audio_drop_highlight(False)
+        if not data:
+            return ""
+        files = self.tk.splitlist(data)
+        if not files:
+            return ""
+        path = files[0]
+        if not os.path.isfile(path):
+            messagebox.showwarning("Audio", "Le fichier déposé est introuvable.", parent=self)
+            return ""
+        if not self._is_supported_audio_file(path):
+            messagebox.showwarning(
+                "Audio",
+                "Seuls les fichiers audio (wav, mp3, m4a, aac, flac, ogg) sont acceptés.",
+                parent=self,
+            )
+            return ""
+        self.stop_audio_recording(keep_result=False, show_message=False)
+        self._apply_selected_audio_file(path)
+        return ""
+
+    def _set_audio_drop_highlight(self, active: bool) -> None:
+        if not self._audio_drop_target:
+            return
+        if active:
+            self._audio_drop_target.configure(background="#d0ebff")
+        else:
+            self._audio_drop_target.configure(background=self._audio_drop_default_bg)
+
+    def _is_supported_audio_file(self, path: str) -> bool:
+        return Path(path).suffix.lower() in AUDIO_FILE_EXTENSIONS
 
     def toggle_audio_recording(self) -> None:
         if self._recording_active:
@@ -367,7 +450,7 @@ class LessonDialog(tk.Toplevel):
             self._discard_temp_recording(self.audio_source_path)
             self.audio_source_path = None
             self._audio_source_is_temp = False
-            self.var_audio_display.set("Aucun fichier audio")
+            self._refresh_audio_display_text(None)
 
         self._recording_stop_event = threading.Event()
         self._recording_finished_event = threading.Event()
@@ -504,7 +587,7 @@ class LessonDialog(tk.Toplevel):
         self._temp_recordings.add(self.audio_source_path)
         self._audio_source_is_temp = True
         self.audio_cleared = False
-        self.var_audio_display.set(self.audio_source_path)
+        self._refresh_audio_display_text(self.audio_source_path)
 
         status = "Enregistrement terminé."
         if self._recording_status_message:
@@ -636,8 +719,20 @@ class LessonScribeApp(tk.Tk):
 
     def _apply_lesson_defaults(self, lesson: Lesson) -> Lesson:
         if not lesson.title and self.default_title_template:
-            date_label = lesson.date or datetime.date.today().isoformat()
-            lesson.title = f"{self.default_title_template} {date_label}".strip()
+            template = self.default_title_template
+            if "{" in template and "}" in template:
+                today = datetime.date.today().isoformat()
+                safe_date = lesson.date or today
+                try:
+                    template = template.format(
+                        date=safe_date,
+                        start=lesson.start or "",
+                        end=lesson.end or "",
+                        minutes=lesson.minutes or "",
+                    )
+                except Exception:
+                    template = self.default_title_template
+            lesson.title = template.strip()
         if lesson.minutes <= 0 and lesson.start and lesson.end:
             computed = minutes_from_times(lesson.start, lesson.end)
             if computed is not None:


### PR DESCRIPTION
## Summary
- stop appending the date/time to default lesson titles while still allowing template formatting
- add an audio drop zone that accepts drag-and-drop files with basic validation and highlighting
- centralize audio display updates so the UI communicates drag-and-drop availability

## Testing
- python -m compileall src/lesson_scribe/app.py

------
https://chatgpt.com/codex/tasks/task_b_68e4ce594a9483328c0fe41ccbc34b00